### PR TITLE
Client initialization parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     nemid (0.1.0)
+      openssl (~> 2.2, >= 2.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
+    openssl (2.2.0)
     rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,24 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+This gem implements one main module:
+
+- `Authentication`: the purpose of this module is to generate client initialization 
+parameters and response handling.
+
+### Authentication::Parameters
+
+Generate client initialization parameters
+
+
+```ruby
+nemid = NemID::Authentication::Parameters.new
+  certificate: 'path/to/certificate', # Rails.env.nemid[:certificate]
+  pass: 'your_voces_certificate_password', # Rails.env.nemid[:pass]
+)
+
+nemid.client_initialization_parameters # returns a ruby hash with parameters
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ parameters and response handling.
 
 Generate client initialization parameters
 
-
 ```ruby
-nemid = NemID::Authentication::Parameters.new
-  certificate: 'path/to/certificate', # Rails.env.nemid[:certificate]
-  pass: 'your_voces_certificate_password', # Rails.env.nemid[:pass]
+nemid = NemID::Authentication::Parameters.new(
+  'path/to/your/voces/certificate',
+  'your_voces_certificate_password',
 )
 
-nemid.client_initialization_parameters # returns a ruby hash with parameters
+nemid.client_initialization_parameters # ruby hash with signed parameters
 ```
 
 ## Development

--- a/lib/nemid.rb
+++ b/lib/nemid.rb
@@ -1,4 +1,5 @@
 require "nemid/version"
+require "nemid/authentication"
 require "nemid/crypto"
 
 module NemID

--- a/lib/nemid.rb
+++ b/lib/nemid.rb
@@ -1,4 +1,5 @@
 require "nemid/version"
+require "nemid/crypto"
 
 module NemID
   class Error < StandardError; end

--- a/lib/nemid/authentication.rb
+++ b/lib/nemid/authentication.rb
@@ -1,0 +1,6 @@
+require_relative "authentication/params"
+
+module NemID
+  module Authentication
+  end
+end

--- a/lib/nemid/authentication/params.rb
+++ b/lib/nemid/authentication/params.rb
@@ -1,6 +1,52 @@
+require 'date'
+
 module NemID
   module Authentication
     class Params
+      def initialize(certificate, pass)
+        @nemid_crypto = NemID::Crypto.new(certificate, pass)
+      end
+  
+      def client_initialization_parameters
+        params = unsigned_params
+        normalized_unsigned_params = normalize(unsigned_params)
+        
+        params.merge({
+          "DIGEST_SIGNATURE": digest_signature(normalized_unsigned_params),
+          "PARAMS_DIGEST": params_digest(normalized_unsigned_params),
+        })
+      end
+  
+      private
+      def digest_signature(normalized_unsigned_params)
+        @nemid_crypto.base64_encoded_rsa_signature(normalized_unsigned_params)
+      end
+  
+      def normalize(params)
+        params = params.transform_keys(&:upcase)
+        
+        str = String.new
+        
+        params.keys.sort.each { |k| str += "#{k.to_s}#{params[k]}" }
+  
+        return str
+      end
+  
+      def params_digest(normalized_unsigned_params)
+        @nemid_crypto.base64_encoded_digest_representation(normalized_unsigned_params)
+      end
+  
+      def sp_cert
+        @nemid_crypto.base64_encoded_der_representation
+      end
+  
+      def unsigned_params
+        {
+          "CLIENTFLOW": "OCESLOGIN2",
+          "SP_CERT": sp_cert,
+          "TIMESTAMP": DateTime.now.new_offset(0).strftime('%F %T%z'),
+        }
+      end
     end
   end
 end

--- a/lib/nemid/authentication/params.rb
+++ b/lib/nemid/authentication/params.rb
@@ -1,0 +1,6 @@
+module NemID
+  module Authentication
+    class Params
+    end
+  end
+end

--- a/lib/nemid/crypto.rb
+++ b/lib/nemid/crypto.rb
@@ -1,0 +1,46 @@
+require 'base64'
+require 'openssl'
+
+module NemID
+ class Crypto
+  
+  def initialize(certificate, pass)
+    certificate = read_file(certificate)
+    @pkcs12 = read_pkcs12(certificate, pass)
+    @rsa_instance = rsa_keypair(@pkcs12, pass)
+  end
+
+  def base64_encoded_der_representation
+    Base64.strict_encode64(@pkcs12.certificate.to_der)
+  end
+
+  def base64_encoded_digest_representation(data)
+    Base64.strict_encode64(digest(data))
+  end
+
+  def base64_encoded_rsa_signature(data)
+    Base64.strict_encode64(sign(data))
+  end
+
+  private
+  def digest(data)
+    OpenSSL::Digest::SHA256.new.digest(data)
+  end
+
+  def read_file(certificate)
+    File.read(certificate)
+  end
+
+  def read_pkcs12(certificate, pass)
+    OpenSSL::PKCS12::new(certificate, pass)
+  end
+
+  def rsa_keypair(pkcs12, passphrase)
+    OpenSSL::PKey::RSA.new(pkcs12.key, passphrase)
+  end
+
+  def sign(data)
+    @rsa_instance.sign(OpenSSL::Digest::SHA256.new, data)
+  end
+ end
+end

--- a/nemid.gemspec
+++ b/nemid.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
+  spec.add_dependency 'openssl', '~> 2.2', '>= 2.2.0'
+
   spec.metadata["allowed_push_host"] = "http://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/spec/nemid_spec.rb
+++ b/spec/nemid_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe NemID do
   it "has a version number" do
     expect(NemID::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
This pull request addresses the client's initialization parameters generation. NemID gives a lot of options when it comes to generating the parameters, such as setting the language of the client for example. However, this implements the minimum number of parameters required to start an authentication flow.

The usage of this feature is as follows:

```ruby
nemid = NemID::Authentication::Params.new('path/to/certificate', 'password') # Preferably take both from env variables.

nemid.client_initialization_parameters # returns the parameters as ruby json 
```