### PR TITLE
Response handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     nemid (0.1.0)
       nokogiri (~> 1.11.0.rc2, >= 1.11.0.rc2)
       openssl (~> 2.2, >= 2.2.0)
+      xmldsig (~> 0.6.6, >= 0.6.6)
 
 GEM
   remote: https://rubygems.org/
@@ -27,6 +28,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    xmldsig (0.6.6)
+      nokogiri (>= 1.6.8, < 2.0.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     nemid (0.1.0)
+      openssl (~> 2.2, >= 2.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
+    openssl (2.2.0)
     rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,16 @@ PATH
   remote: .
   specs:
     nemid (0.1.0)
+      nokogiri (~> 1.11.0.rc2, >= 1.11.0.rc2)
       openssl (~> 2.2, >= 2.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.0.rc2)
+      mini_portile2 (~> 2.5.0)
     openssl (2.2.0)
     rake (12.3.3)
     rspec (3.9.0)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ nemid = NemID::Authentication::Parameters.new(
 nemid.client_initialization_parameters # ruby hash with signed parameters
 ```
 
+### Authentication::Response
+
+Parse nemid response and extract user information from certificate. Right now,
+it is only possible to extract the PID (or RID).
+
+```ruby
+response = NemID::Authentication::Response.new(base64_str) # Base64 string from NemID
+
+# or
+
+response = NemID::Authentication::Response.new(xml_str) # XML string from NemID
+
+# Extract PID or RID
+response.extract_pid_or_rid # "PID:9208-2002-2-316380231171"
+
+# Has PID?
+response.has_pid? # true
+
+# Extract PID
+response.extract_pid # "9208-2002-2-316380231171"
+
+# Has RID?
+response.has_rid? # false
+
+# Extract RID
+response.extract_rid # nil
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+This gem implements one main module:
+
+- `Authentication`: the purpose of this module is to generate client initialization 
+parameters and response handling.
+
+### Authentication::Parameters
+
+Generate client initialization parameters
+
+```ruby
+nemid = NemID::Authentication::Parameters.new(
+  'path/to/your/voces/certificate',
+  'your_voces_certificate_password',
+)
+
+nemid.client_initialization_parameters # ruby hash with signed parameters
+```
 
 ## Development
 

--- a/lib/nemid.rb
+++ b/lib/nemid.rb
@@ -1,4 +1,6 @@
 require "nemid/version"
+require "nemid/authentication"
+require "nemid/crypto"
 
 module NemID
   class Error < StandardError; end

--- a/lib/nemid.rb
+++ b/lib/nemid.rb
@@ -1,6 +1,8 @@
+require 'base64'
 require "nemid/version"
 require "nemid/authentication"
 require "nemid/crypto"
+require "nemid/xmldsig"
 
 module NemID
   class Error < StandardError; end

--- a/lib/nemid/authentication.rb
+++ b/lib/nemid/authentication.rb
@@ -1,6 +1,8 @@
-require_relative "authentication/params"
-
 module NemID
   module Authentication
+    class ResponseError < StandardError; end
   end
 end
+
+require_relative "authentication/params"
+require_relative "authentication/response"

--- a/lib/nemid/authentication.rb
+++ b/lib/nemid/authentication.rb
@@ -1,0 +1,6 @@
+require_relative "authentication/params"
+
+module NemID
+  module Authentication
+  end
+end

--- a/lib/nemid/authentication/params.rb
+++ b/lib/nemid/authentication/params.rb
@@ -1,0 +1,52 @@
+require 'date'
+
+module NemID
+  module Authentication
+    class Params
+      def initialize(certificate, pass)
+        @nemid_crypto = NemID::Crypto.new(certificate, pass)
+      end
+  
+      def client_initialization_parameters
+        params = unsigned_params
+        normalized_unsigned_params = normalize(unsigned_params)
+        
+        params.merge({
+          "DIGEST_SIGNATURE": digest_signature(normalized_unsigned_params),
+          "PARAMS_DIGEST": params_digest(normalized_unsigned_params),
+        })
+      end
+  
+      private
+      def digest_signature(normalized_unsigned_params)
+        @nemid_crypto.base64_encoded_rsa_signature(normalized_unsigned_params)
+      end
+  
+      def normalize(params)
+        params = params.transform_keys(&:upcase)
+        
+        str = String.new
+        
+        params.keys.sort.each { |k| str += "#{k.to_s}#{params[k]}" }
+  
+        return str
+      end
+  
+      def params_digest(normalized_unsigned_params)
+        @nemid_crypto.base64_encoded_digest_representation(normalized_unsigned_params)
+      end
+  
+      def sp_cert
+        @nemid_crypto.base64_encoded_der_representation
+      end
+  
+      def unsigned_params
+        {
+          "CLIENTFLOW": "OCESLOGIN2",
+          "SP_CERT": sp_cert,
+          "TIMESTAMP": DateTime.now.new_offset(0).strftime('%F %T%z'),
+        }
+      end
+    end
+  end
+end

--- a/lib/nemid/authentication/response.rb
+++ b/lib/nemid/authentication/response.rb
@@ -1,0 +1,17 @@
+module NemID
+  module Authentication
+    class Response
+      
+      def initialize(string)
+        if string.start_with? '<?xml'
+          NemID::XMLDSig::Document.new(string)
+        elsif string.match?(/\A[A-Za-z0-9+\/\r\n]+={0,2}\z/)
+          NemID::XMLDSig::Document.new(Base64.decode64(string))
+        else
+          raise NemID::Authentication::ResponseError
+        end
+      end
+
+    end
+  end
+end

--- a/lib/nemid/authentication/response.rb
+++ b/lib/nemid/authentication/response.rb
@@ -1,17 +1,47 @@
 module NemID
   module Authentication
     class Response
-      
+      PID_REGEX = /\APID:([0-9-]+)\Z/.freeze
+      RID_REGEX = /\ARID:([0-9-]+)\Z/.freeze
+
       def initialize(string)
         if string.start_with? '<?xml'
-          NemID::XMLDSig::Document.new(string)
+          @doc = NemID::XMLDSig::Document.new(string)
         elsif string.match?(/\A[A-Za-z0-9+\/\r\n]+={0,2}\z/)
-          NemID::XMLDSig::Document.new(Base64.decode64(string))
+          @doc = NemID::XMLDSig::Document.new(Base64.decode64(string))
         else
           raise NemID::Authentication::ResponseError
         end
       end
 
+      def extract_pid
+        if has_pid?
+          serial_number.match(PID_REGEX)[1]
+        end
+      end
+
+      def extract_rid
+        if has_rid?
+          serial_number.match(RID_REGEX)[1]
+        end
+      end
+
+      def extract_pid_or_rid
+        serial_number
+      end
+
+      def has_pid?
+        serial_number.match?(PID_REGEX)
+      end
+
+      def has_rid?
+        serial_number.match?(RID_REGEX)
+      end
+
+      private
+      def serial_number
+        @serial_number ||= @doc.extract_pid_or_rid
+      end
     end
   end
 end

--- a/lib/nemid/crypto.rb
+++ b/lib/nemid/crypto.rb
@@ -1,4 +1,3 @@
-require 'base64'
 require 'openssl'
 
 module NemID

--- a/lib/nemid/crypto.rb
+++ b/lib/nemid/crypto.rb
@@ -1,0 +1,46 @@
+require 'base64'
+require 'openssl'
+
+module NemID
+ class Crypto
+  
+  def initialize(certificate, pass)
+    certificate = read_file(certificate)
+    @pkcs12 = read_pkcs12(certificate, pass)
+    @rsa_instance = rsa_keypair(@pkcs12, pass)
+  end
+
+  def base64_encoded_der_representation
+    Base64.strict_encode64(@pkcs12.certificate.to_der)
+  end
+
+  def base64_encoded_digest_representation(data)
+    Base64.strict_encode64(digest(data))
+  end
+
+  def base64_encoded_rsa_signature(data)
+    Base64.strict_encode64(sign(data))
+  end
+
+  private
+  def digest(data)
+    OpenSSL::Digest::SHA256.new.digest(data)
+  end
+
+  def read_file(certificate)
+    File.read(certificate)
+  end
+
+  def read_pkcs12(certificate, pass)
+    OpenSSL::PKCS12::new(certificate, pass)
+  end
+
+  def rsa_keypair(pkcs12, passphrase)
+    OpenSSL::PKey::RSA.new(pkcs12.key, passphrase)
+  end
+
+  def sign(data)
+    @rsa_instance.sign(OpenSSL::Digest::SHA256.new, data)
+  end
+ end
+end

--- a/lib/nemid/xmldsig.rb
+++ b/lib/nemid/xmldsig.rb
@@ -1,5 +1,34 @@
+require 'xmldsig'
+
 module NemID
   module XMLDSig
+    NAMESPACES = {
+      'ds' => 'http://www.w3.org/2000/09/xmldsig#',
+      'openoces' => 'http://www.openoces.org/2006/07/signature#',
+      "ec"  => "http://www.w3.org/2001/10/xml-exc-c14n#",
+      "wsu" => "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+    }
+    
+    # The "referenced_node" method needs to be overridden since NemID uses 
+    # "Id" (as opposed to ID or wsu:Id) as the attribute name in the "Signature" 
+    # element of the XML document.
+    Xmldsig::Reference.class_eval do
+      def referenced_node
+        if reference_uri && reference_uri != ""
+          id = reference_uri[1..-1]
+          if ref = document.dup.at_xpath("//*[@ID='#{id}' or @Id='#{id}' or @wsu:Id='#{id}']", NAMESPACES)
+            ref
+          else
+            raise(
+                ReferencedNodeNotFound,
+                "Could not find the referenced node #{id}'"
+            )
+          end
+        else
+          document.dup.root
+        end
+      end
+    end
   end
 end
 

--- a/lib/nemid/xmldsig.rb
+++ b/lib/nemid/xmldsig.rb
@@ -1,0 +1,6 @@
+module NemID
+  module XMLDSig
+  end
+end
+
+require_relative "xmldsig/document"

--- a/lib/nemid/xmldsig/document.rb
+++ b/lib/nemid/xmldsig/document.rb
@@ -2,9 +2,30 @@ require 'nokogiri'
 
 module NemID
   module XMLDSig
-    class Document
-      def initialize(xml)
-        @document = Nokogiri::XML(xml)
+    class Document < Xmldsig::SignedDocument
+
+      def extract_pid_or_rid
+        user_certificate = get_user_certificate
+        return user_certificate.subject.to_a.assoc("serialNumber")[1]
+      end
+
+      def get_user_certificate
+        certificates.each do |element|
+          cert = x509_certificate(Base64.decode64(element.text))
+          cert_key_usage = cert.find_extension('keyUsage').value
+          
+          return cert if (cert_key_usage =~ /Digital Signature/)
+        end
+      end
+      
+      private
+      def certificates
+        xpath = '//ds:KeyInfo/ds:X509Data/ds:X509Certificate'
+        document.xpath(xpath, NAMESPACES).each
+      end
+
+      def x509_certificate(raw)
+        OpenSSL::X509::Certificate.new(raw)
       end
     end
   end

--- a/lib/nemid/xmldsig/document.rb
+++ b/lib/nemid/xmldsig/document.rb
@@ -1,0 +1,11 @@
+require 'nokogiri'
+
+module NemID
+  module XMLDSig
+    class Document
+      def initialize(xml)
+        @document = Nokogiri::XML(xml)
+      end
+    end
+  end
+end

--- a/nemid.gemspec
+++ b/nemid.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.add_dependency 'openssl', '~> 2.2', '>= 2.2.0'
+  spec.add_dependency 'nokogiri', '~> 1.11.0.rc2', '>= 1.11.0.rc2'
 
   spec.metadata["allowed_push_host"] = "http://rubygems.org"
 

--- a/nemid.gemspec
+++ b/nemid.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
+  spec.add_dependency 'openssl', '~> 2.2', '>= 2.2.0'
+
   spec.metadata["allowed_push_host"] = "http://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/nemid.gemspec
+++ b/nemid.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency 'openssl', '~> 2.2', '>= 2.2.0'
   spec.add_dependency 'nokogiri', '~> 1.11.0.rc2', '>= 1.11.0.rc2'
+  spec.add_dependency 'openssl', '~> 2.2', '>= 2.2.0'
+  spec.add_dependency 'xmldsig', '~> 0.6.6', '>= 0.6.6'
 
   spec.metadata["allowed_push_host"] = "http://rubygems.org"
 

--- a/spec/nemid_spec.rb
+++ b/spec/nemid_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe NemID do
   it "has a version number" do
     expect(NemID::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
The purpose of this feature is to handle the base64 (or XML) response coming from NemID after the client has been successfully authenticated. This feature should:

* Extract user information from the certificate.

This feature should also perform the 5 verification steps NemID states in the documentation.

The usage of this feature is as follows:

```ruby
response = NemID::Authentication::Response.new(base64) # Base64 string from NemID

# or

response = NemID::Authentication::Response.new(xml) # XML string from NemID

# Extract PID or RID
response.extract_pid_or_rid # "PID:9208-2002-2-316380231171"

# Has PID?
response.has_pid? # true

# Extract PID
response.extract_pid # "9208-2002-2-316380231171"

# Has RID?
response.has_rid? # false

# Extract RID
response.extract_rid # nil
```