### PR TITLE
Improve certificate and key reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Match a PID to a CPR number.
 
 ```ruby
 pid_cpr = NemID::PIDCPR.new(
-  cert: 'your_voces_certificate_in_pem_format'
+  cert: 'your_voces_certificate_in_pem_format',
   key: 'your_private_key_in_pem_format',
   spid: 'your_service_provider_id'
 )

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This gem implements the following modules:
 
 - `OCSP:` use this if you want to manually perform an OCSP request.
 
-### Authentication::Parameters
+### Authentication::Params
 
-Generate client initialization parameters
+Generate client initialization parameters. See [here](https://github.com/davideluque/nemid#extracting-certificate-and-private-key) if you do not know how to get your certificate and private key in pem format.
 
 ```ruby
-nemid = NemID::Authentication::Parameters.new(
-  'path/to/your/voces/certificate',
-  'your_voces_certificate_password',
+nemid = NemID::Authentication::Params.new(
+  cert: 'your_voces_certificate_in_pem_format'
+  key: 'your_private_key_in_pem_format',
 )
 
 nemid.client_initialization_parameters # ruby hash with signed parameters
@@ -91,9 +91,9 @@ Match a PID to a CPR number.
 
 ```ruby
 pid_cpr = NemID::PIDCPR.new(
-  'your_service_provider_id',
-  'path/to/your/voces/certificate',
-  'your_voces_certificate_password'
+  cert: 'your_voces_certificate_in_pem_format'
+  key: 'your_private_key_in_pem_format',
+  spid: 'your_service_provider_id'
 )
 
 pid_cpr.match(pid: '9208-2002-2-316380231171', cpr: '2205943423')
@@ -153,6 +153,8 @@ rescue NemID::OCSP::NonceError => e
   puts e # Nonces both present and not equal
 end
 ```
+
+## Extracting Certificate and Private Key
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This gem implements the following modules:
 
 ### Authentication::Params
 
-Generate client initialization parameters. See [here](https://github.com/davideluque/nemid#extracting-certificate-and-private-key) if you do not know how to get your certificate and private key in pem format.
+Generate client initialization parameters. See [here](https://github.com/davideluque/nemid#exporting-certificate-and-private-key) if you do not know how to get your certificate and private key in pem format.
 
 ```ruby
 nemid = NemID::Authentication::Params.new(
@@ -43,7 +43,7 @@ nemid.client_initialization_parameters # ruby hash with signed parameters
 
 ### Authentication::Response
 
-Parse and validate NemID response, then extract user information from certificate. As of this version, it is only possible to extract the PID (or RID).
+Parse and validate NemID response, then export user information from certificate. As of this version, it is only possible to export the PID (or RID).
 
 ```ruby
 response = NemID::Authentication::Response.new(base64_str) # Base64 string from NemID
@@ -154,7 +154,42 @@ rescue NemID::OCSP::NonceError => e
 end
 ```
 
-## Extracting Certificate and Private Key
+## Exporting Certificate and Private Key
+
+To be able to export the certificate and the key, you will be prompted the password that NemID used to encrypt the p12 archive. It should have been sent to you together with the p12 file.
+
+Exporting the certificate:
+
+```bash
+# Replace <filename.p12> with the file name of the p12 that NemID sent to you
+$ openssl pkcs12 -in <filename.p12> -clcerts -nokeys | openssl x509 -out cert.cer
+```
+
+Exporting the key:
+
+```bash
+# Replace <filename.p12> with the file name of the p12 that NemID sent to you
+$ openssl pkcs12 -in <filename.p12> -nocerts -nodes | openssl pkcs8 -nocrypt -out private_key.key
+```
+
+After you export both files, you will need to manually replace the newlines with `\n`, in both. 
+
+
+If everything went well, you should have two one-line strings that look like this (but longer):
+
+```
+-----BEGIN CERTIFICATE-----\nMIIGETCCBPmgAwIBAgIEX(a-lot-of-alphanumeric-characters-and-\n)wIBAgIE\n-----END CERTIFICATE-----\n
+
+and
+
+-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC8fX6t4Hkhxl+FM=\n-----END PRIVATE KEY-----\n
+```
+
+**Notice the trailing \n, it is very important that you include it**. 
+
+If you get an error like `(nested asn1 error)`, it means that you have done something wrong when editing the file. Try exporting again and carefully replace the newlines with \n.
+
+Keep these files private to you, use environment variables!
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ rescue NemID::Errors::ResponseValidationError => e
   puts e # Developer-friendly message, example: Signature is invalid.
 end
 
-# Note that response.validate_response raises exceptions instead of returning true or false, the exceptions are raised according to the order that the  methods are invoked. The following methods perform the same validations and do not raise exceptions:
+# Note that response.validate_response raises exceptions instead of returning true or false, the exceptions are 
+# raised according to the order that the  methods are invoked. The following methods perform the same validations 
+# and do not raise exceptions:
 
 response.valid_signature? # true
 response.valid_certificate_chain? # true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Generate client initialization parameters. See [here](https://github.com/davidel
 
 ```ruby
 nemid = NemID::Authentication::Params.new(
-  cert: 'your_voces_certificate_in_pem_format'
+  cert: 'your_voces_certificate_in_pem_format',
   key: 'your_private_key_in_pem_format',
 )
 

--- a/lib/nemid/authentication/params.rb
+++ b/lib/nemid/authentication/params.rb
@@ -3,8 +3,8 @@ require 'date'
 module NemID
   module Authentication
     class Params
-      def initialize(certificate, pass)
-        @nemid_crypto = NemID::Crypto.new(certificate, pass)
+      def initialize(cert:, key:)
+        @nemid_crypto = NemID::Crypto.new(cert: cert, key: key)
       end
   
       def client_initialization_parameters

--- a/lib/nemid/crypto.rb
+++ b/lib/nemid/crypto.rb
@@ -3,14 +3,13 @@ require 'openssl'
 module NemID
  class Crypto
 
-  def initialize(certificate, pass)
-    certificate = read_file(certificate)
-    @pkcs12 = read_pkcs12(certificate, pass)
-    @rsa_instance = rsa_keypair(@pkcs12, pass)
+  def initialize(cert:, key:)
+    @certificate = read_x509(cert)
+    @rsa_instance = rsa_keypair(key)
   end
 
   def base64_encoded_der_representation
-    Base64.strict_encode64(@pkcs12.certificate.to_der)
+    Base64.strict_encode64(@certificate.to_der)
   end
 
   def base64_encoded_digest_representation(data)
@@ -22,11 +21,11 @@ module NemID
   end
 
   def get_certificate
-    @pkcs12.certificate
+    @certificate
   end
 
   def get_key
-    @pkcs12.key
+    @rsa_instance
   end
   
   private
@@ -38,12 +37,12 @@ module NemID
     File.read(certificate)
   end
 
-  def read_pkcs12(certificate, pass)
-    OpenSSL::PKCS12::new(certificate, pass)
+  def read_x509(raw)
+    OpenSSL::X509::Certificate.new(raw)
   end
 
-  def rsa_keypair(pkcs12, passphrase)
-    OpenSSL::PKey::RSA.new(pkcs12.key, passphrase)
+  def rsa_keypair(raw)
+    OpenSSL::PKey::RSA.new(raw)
   end
 
   def sign(data)

--- a/lib/nemid/pid_cpr.rb
+++ b/lib/nemid/pid_cpr.rb
@@ -4,8 +4,8 @@ module NemID
   class PIDCPR
     PID_SERVICE_URL = 'https://pidws.pp.certifikat.dk/pid_serviceprovider_server/pidws'
 
-    def initialize(spid, cert, pass)
-      @crypto = NemID::Crypto.new(cert, pass)
+    def initialize(cert:, key:, spid:)
+      @crypto = NemID::Crypto.new(cert: cert, key: key)
       @spid = spid
     end
 


### PR DESCRIPTION
**Two reasons to implement this feature:**

First, this PR adds a performance improvement to the library: the PKCS #12 file was read every time the `Crypto` class was initialized. The crypto class was initialized when client initialization parameters were requested or when matching PIDs to CPRs.  I/O operations are extremely expensive.

Second, I found out that storing as a file the PKCS #12 in our Rails application was quite bothersome since we do not want to 
upload the file to the CVS, hindering the Continuous Integration pipeline, quick deployment, certificate replacing, among others.

**If not as files, how then?**

The definition of a PKCS #12 file, according to Wikipedia:

> PKCS #12 defines an archive file format for storing many cryptography objects as a single file. It is commonly used to bundle a private key with its X.509 certificate or to bundle all the members of a chain of trust.

With openssl we can export from the PKCS #12 file the X.509 certificate(s) and the private key. 

As of right now, the end-entity certificate (leaf certificate) and the private key are the only two objects that we need to generate client initialization parameters and to make PID-CPR requests.

Now, according to ssh.com, this is the purpose of the password:

![image](https://user-images.githubusercontent.com/10492210/94379800-9ff20c00-0100-11eb-8484-847afae12459.png)

I was able to generate client initialization parameters without providing the password, and I would consider `signing` as "using" the private key. I am thinking that this is because once you have exported the key to .pem format you already passed the password requirement, so one should be careful about where the private key is stored, a suggestion is to store it in the encrypted credentials. 

This is also not a new practice, Apple Sign In requires storing their private key in the backend application order to sign parameters.