### PR TITLE
Add prod. url to pidcpr

### DIFF
--- a/lib/nemid.rb
+++ b/lib/nemid.rb
@@ -1,6 +1,7 @@
 require 'base64'
 require "nemid/version"
 require "nemid/authentication"
+require "nemid/configuration"
 require "nemid/crypto"
 require "nemid/errors"
 require "nemid/ocsp"
@@ -8,5 +9,21 @@ require "nemid/xmldsig"
 require 'nemid/pid_cpr'
 
 module NemID
+  class << self
+    attr_accessor :configuration
+  end
+  
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
   class Error < StandardError; end
 end

--- a/lib/nemid/configuration.rb
+++ b/lib/nemid/configuration.rb
@@ -1,0 +1,17 @@
+module NemID
+  class Configuration
+    attr_accessor :env, :oces_certificate, :private_key, :spid
+
+    def initialize
+      @env = default_for_env
+      @oces_cert = nil
+      @private_key = nil
+      @spid = nil
+    end
+
+    def default_for_env
+      return Rails.env.to_s if defined?(Rails.env)
+      ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+    end
+  end
+end

--- a/lib/nemid/pid_cpr.rb
+++ b/lib/nemid/pid_cpr.rb
@@ -2,7 +2,6 @@ require 'savon'
 
 module NemID
   class PIDCPR
-    PID_SERVICE_URL = 'https://pidws.pp.certifikat.dk/pid_serviceprovider_server/pidws'
 
     def initialize(cert:, key:, spid:)
       @crypto = NemID::Crypto.new(cert: cert, key: key)
@@ -46,11 +45,20 @@ module NemID
       }
     end
 
+    def pid_service_url
+      case NemID.configuration.env
+      when 'production', 'staging'
+        'https://pidws.certifikat.dk/pid_serviceprovider_server/pidws/'
+      else
+        'https://pidws.pp.certifikat.dk/pid_serviceprovider_server/pidws'
+      end
+    end
+
     def soap_client
       options = {
-        :wsdl => "#{PID_SERVICE_URL}?WSDL",
+        :wsdl => "#{pid_service_url}?WSDL",
         :soap_version => 1,
-        :endpoint => PID_SERVICE_URL,
+        :endpoint => pid_service_url,
         :convert_request_keys_to => :none,
         :ssl_cert => @crypto.get_certificate,
         :ssl_cert_key => @crypto.get_key,


### PR DESCRIPTION
Uses gem configurable options to set the production url when the environment is production or staging. Not sure if this is the best way to do this